### PR TITLE
feat: Environment variables support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,16 +509,6 @@ checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "expand-tilde"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe87936997d5c494d74ce2bfc9baf7f2ec25eda659f867364f29ad117a66b7d"
-dependencies = [
- "home",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -959,6 +960,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,7 +1393,9 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
+ "bstr",
  "dirs",
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1480,7 +1492,6 @@ dependencies = [
  "clap-serde-derive",
  "color-eyre",
  "duct",
- "expand-tilde",
  "flexi_logger",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ rust-version = "1.81.0"
 
 [dependencies]
 clap-serde-derive = "0.2.1"
-expand-tilde = "0.6.0"
 flexi_logger = "0.30.1"
 ssh-agent-lib = "0.5.1"
 toml = "0.8.22"
-shellexpand = "3.1.1"
+
+[dependencies.shellexpand]
+version = "3.1.1"
+features = ["path"]
 
 [dependencies.color-eyre]
 version = "0.6.3"

--- a/src/bin/ssh-agent-mux/cli.rs
+++ b/src/bin/ssh-agent-mux/cli.rs
@@ -10,22 +10,25 @@ use clap_serde_derive::{
     serde::{self, Deserialize, Serialize},
     ClapSerde,
 };
-use color_eyre::eyre::{eyre, Result as EyreResult};
-use expand_tilde::ExpandTilde;
+use color_eyre::eyre::Result as EyreResult;
 use log::LevelFilter;
 
 use crate::service;
 
 fn default_config_path() -> PathBuf {
     let config_dir = env::var_os("XDG_CONFIG_HOME")
-        .or_else(|| Some("~/.config".into()))
         .map(PathBuf::from)
-        .and_then(|p| p.expand_tilde_owned().ok())
-        .expect("HOME not defined in environment");
+        .unwrap_or_else(|| "~/.config".into());
 
     config_dir
         .join(env!("CARGO_PKG_NAME"))
         .join(concat!(env!("CARGO_PKG_NAME"), ".toml"))
+}
+
+fn expand_path(path: impl AsRef<Path>) -> EyreResult<PathBuf> {
+    shellexpand::path::full(path.as_ref())
+        .map(|p| p.into_owned())
+        .map_err(|e| e.into())
 }
 
 #[derive(Parser)]
@@ -75,6 +78,7 @@ pub struct Config {
 impl Config {
     pub fn parse() -> EyreResult<Self> {
         let mut args = Args::parse();
+        args.config_path = expand_path(args.config_path)?;
 
         let mut config = if let Ok(mut f) = File::open(&args.config_path) {
             log::info!("Read configuration from {}", args.config_path.display());
@@ -86,21 +90,13 @@ impl Config {
             Config::from(&mut args.config)
         };
 
-        fn expand_path(p: &Path) -> EyreResult<PathBuf> {
-            let p = p
-                .to_str()
-                .ok_or_else(|| eyre!("failed to convert {} to str", p.display()))?;
-            let expanded = shellexpand::full(p)?;
-            Ok(PathBuf::from(&expanded as &str))
-        }
-
         config.config_path = args.config_path;
-        config.listen_path = config.listen_path.expand_tilde_owned()?;
-        config.log_file = config.log_file.map(|p| expand_path(&p)).transpose()?;
+        config.listen_path = expand_path(config.listen_path)?;
+        config.log_file = config.log_file.map(expand_path).transpose()?;
         config.agent_sock_paths = config
             .agent_sock_paths
             .into_iter()
-            .map(|p| expand_path(&p))
+            .map(expand_path)
             .collect::<Result<_, _>>()?;
 
         Ok(config)
@@ -127,5 +123,50 @@ impl From<LogLevel> for LevelFilter {
             LogLevel::Debug => LevelFilter::Debug,
             LogLevel::Trace => LevelFilter::Trace,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FAKE_ENV_VAR: &str = "CARGO_TEST_EXAMPLE";
+    const FAKE_SOCK_PATH: &str = "/path/to/nonexistent/socket.sock";
+
+    #[test]
+    fn expand_env_variable() {
+        env::set_var(FAKE_ENV_VAR, FAKE_SOCK_PATH);
+        let to_be_expanded = PathBuf::from(format!("${{{FAKE_ENV_VAR}}}"));
+        let expected = PathBuf::from(FAKE_SOCK_PATH);
+        let actual = expand_path(to_be_expanded).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn expand_tilde() {
+        env::set_var("HOME", "/home/fake");
+        let to_be_expanded = PathBuf::from("~/subdir_in_home");
+        let expected = PathBuf::from("/home/fake/subdir_in_home");
+        let actual = expand_path(to_be_expanded).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn expand_env_multiple() {
+        env::set_var("CARGO_TEST_VAR_1", "one");
+        env::set_var("CARGO_TEST_VAR_2", "two");
+        let to_be_expanded = PathBuf::from("{${CARGO_TEST_VAR_1}.${CARGO_TEST_VAR_2}}");
+        let expected = PathBuf::from("{one.two}");
+        let actual = expand_path(to_be_expanded).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn expand_env_escaping() {
+        env::set_var(FAKE_ENV_VAR, FAKE_SOCK_PATH);
+        let to_be_expanded = PathBuf::from(format!("$${{{FAKE_ENV_VAR}}}"));
+        let expected = PathBuf::from(format!("${{{FAKE_ENV_VAR}}}"));
+        let actual = expand_path(to_be_expanded).unwrap();
+        assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
First thing first, thank you for an awesome tool, it simplified my life a lot.

On macos the `SSH_AUTH_SOCK` variable is changed on between startups, it would've been very handy if one could specify `SSH_AUTH_SOCK` as an environment variable in config like this:

```toml
agent_sock_paths = [
	"${SSH_AUTH_SOCK}",
	# ...
]
```

There is also a bit that is responsible for config generation, not sure what's desired behavior there, it should either
- Add current value of `SSH_AUTH_SOCK` into the config (as it is now)
- Add the placeholder and hope that this variable is set on daemon startup

Not sure if the second option is viable on every system though