### PR TITLE
fix: Skip upstream agents that error when listing identities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,20 @@ impl MuxAgent {
                     continue;
                 }
             };
-            let agent_identities = client.request_identities().await?;
+            let agent_identities = match client.request_identities().await {
+                Ok(ids) => ids,
+                Err(e) => {
+                    // A reachable-but-misbehaving upstream (e.g. one mid-restart, or
+                    // one with a partial agent-protocol implementation) must not take
+                    // down every other agent's keys. Skip it, like a missing socket.
+                    log::warn!(
+                        "Ignoring upstream agent that failed to list identities <{}>: {}",
+                        sock_path.display(),
+                        e
+                    );
+                    continue;
+                }
+            };
             {
                 for id in &agent_identities {
                     known_keys.insert(id.pubkey.clone(), sock_path.clone());


### PR DESCRIPTION
### Problem

`refresh_identities` already tolerates an upstream whose socket is missing or
refuses the connection — it logs a warning and `continue`s. But if an upstream
socket is *reachable* and then returns an **error** to `request_identities`, the
`?` propagated it and aborted the entire refresh, dropping every other agent's
keys too (and failing the client's list/sign).

This happens with an agent that has a partial ssh-agent protocol implementation
(e.g. rbw's Bitwarden ssh-agent), or one that is momentarily mid-restart: a
single flaky upstream takes the whole mux down until it is restarted.

### Reproduction

A good agent plus one upstream that answers `request_identities` with
`SSH_AGENT_FAILURE`, both behind the mux:

```
# unpatched
$ SSH_AUTH_SOCK=$mux ssh-add -l
error fetching identities: agent refused operation      # the good agent's key is gone too

# patched
$ SSH_AUTH_SOCK=$mux ssh-add -l
256 SHA256:… testkey (ED25519)                          # bad upstream skipped, good key served
```

### Fix

Handle a `request_identities` error the same way a missing socket is already
handled — log a warning and skip that upstream — so the remaining agents keep
working. One-line-of-logic change, mirroring the `connect_upstream_agent` error
arm directly above it.
