### PR TITLE
Proxy SSH certificates via ssh-agent-lib 0.6 PublicCredential (fix #56)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "ssh-agent-lib"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf67cca8055cc41de60ac7344a98b9c8f9e2a9ee9b1adf3e142b78ec1e7abba"
+checksum = "b528981371b3bfdfe927a5ef37221446e0ba44551e673b569fd0fd38e5dcb292"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1513,7 +1513,7 @@ dependencies = [
  "ssh-encoding",
  "ssh-key",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.83.0"
 [dependencies]
 clap-serde-derive = "0.2.1"
 flexi_logger = "0.31.7"
-ssh-agent-lib = "0.5.1"
+ssh-agent-lib = "0.6.0"
 toml = "0.9.8"
 
 [dependencies.shellexpand]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,16 @@ impl Session for MuxAgent {
     }
 
     async fn sign(&mut self, request: SignRequest) -> Result<Signature, AgentError> {
-        let fingerprint = request.pubkey.fingerprint(Default::default());
+        let fingerprint = request
+            .credential
+            .key_data()
+            .fingerprint(Default::default());
         log::trace!("incoming: sign({})", &fingerprint);
 
-        if let Some(agent_sock_path) = self.get_agent_sock_for_pubkey(&request.pubkey).await? {
+        if let Some(agent_sock_path) = self
+            .get_agent_sock_for_pubkey(request.credential.key_data())
+            .await?
+        {
             log::info!(
                 "Requesting signature with key {} from upstream agent <{}>",
                 &fingerprint,
@@ -215,7 +221,11 @@ impl MuxAgent {
             };
             {
                 for id in &agent_identities {
-                    known_keys.insert(id.pubkey.clone(), sock_path.clone());
+                    // Key the map by the underlying public key. For an OpenSSH
+                    // certificate this is the cert's public key, which also matches
+                    // the plain-key sign request that ssh issues, so both resolve to
+                    // the same upstream agent.
+                    known_keys.insert(id.credential.key_data().clone(), sock_path.clone());
                 }
             }
             log::trace!(


### PR DESCRIPTION
## Summary

Fixes #56: an SSH certificate in any upstream agent made the mux unusable — `ssh-add -l` returned `incomplete message`, and with #94 merged it instead silently dropped every other agent's keys.

`ssh-agent-lib` 0.5.1 typed identities as `ssh_key::public::KeyData`, which cannot represent an OpenSSH certificate. `request_identities` decoded a `…-cert-v01@openssh.com` blob into a lossy opaque key (only the certificate nonce survived) and re-serialized a truncated identity, so an OpenSSH client parsing it back as a certificate ran out of bytes.

This bumps to `ssh-agent-lib` 0.6.0, whose `PublicCredential` (`Key(KeyData) | Cert(Box<Certificate>)`) round-trips certificates losslessly in both identity listings and sign requests. The `known_keys` map is now keyed by `credential.key_data()`, so a certificate, its bare public key, and the sign request OpenSSH issues all resolve to the same upstream agent.

## Scope / ssh-key 0.7

`ssh-agent-lib` 0.6.0 builds on the **released** `ssh-key` 0.6.7 — no pre-release or patched dependency. Certificates with a real `valid_before` (as OpenSSH and correctly configured issuers produce) round-trip fine.

The one remaining gap is certificates minted with `valid_before = u64::MAX` (`Valid: forever`): `ssh-key` 0.6.7 rejects those with `SSH key error: invalid time` (RustCrypto/SSH#504, fixed in `ssh-key` 0.7). That is an `ssh-key` limitation, not the mux — and arguably such certs should not be minted (a certificate that carries an expiring token's authorization should expire with it; see openpubkey/opkssh#606).

## Testing

Verified against real certificates:

- `ssh-add -l` through the mux lists both the bare key and the `…cert-v01@openssh.com` certificate (previously `incomplete message`).
- `ssh-add -T` signs through the mux for both the key and the certificate, routing to the upstream that holds it.

The certificate integration test added in #66 exercises this path.
